### PR TITLE
chore: remove unused color-convert dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,11 +1645,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-    },
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/andyjansson/css-color-converter",
   "dependencies": {
-    "color-convert": "^0.5.2",
     "color-name": "^1.1.4",
     "css-unit-converter": "^1.1.2"
   },


### PR DESCRIPTION
Remove color-convert since it's unused after the 2.0 rewrite.