### PR TITLE
Add missing support for hsl format syntax without comma

### DIFF
--- a/src/__tests__/test.mjs
+++ b/src/__tests__/test.mjs
@@ -21,9 +21,13 @@ deepStrictEqual(fromString('rgba(255 255 255 / .5)').toHslaArray(), [0, 0, 100, 
 deepStrictEqual(fromString('rgba(0, 0, 0, 0)').toRgbaArray(), [0, 0, 0, 0]);
 deepStrictEqual(fromString('rgba(3, 2, 1, 0)').toRgbaArray(), [3, 2, 1, 0]);
 deepStrictEqual(fromString('hsl(0, 0%, 100%)').toHslaArray(), [0, 0, 100, 1]);
+deepStrictEqual(fromString('hsl(0 0% 100%)').toHslaArray(), [0, 0, 100, 1]);
 deepStrictEqual(fromString('hsl(0, 0%, 100%)').toRgbaArray(), [255, 255, 255, 1]);
+deepStrictEqual(fromString('hsl(0 0% 100%)').toRgbaArray(), [255, 255, 255, 1]);
 deepStrictEqual(fromString('hsla(0, 0%, 100%, .5)').toHslaArray(), [0, 0, 100, 0.5]);
+deepStrictEqual(fromString('hsla(0 0% 100% / .5)').toHslaArray(), [0, 0, 100, 0.5]);
 deepStrictEqual(fromString('hsla(0, 0%, 100%, .5)').toRgbaArray(), [255, 255, 255, 0.5]);
+deepStrictEqual(fromString('hsla(0 0% 100% / .5)').toRgbaArray(), [255, 255, 255, 0.5]);
 deepStrictEqual(fromString('#ffffff').toRgbaArray(), [255, 255, 255, 1]);
 deepStrictEqual(fromString('#ffffff').toHslaArray(), [0, 0, 100, 1]);
 deepStrictEqual(fromString('#ffffffff').toRgbaArray(), [255, 255, 255, 1]);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -7,7 +7,8 @@ const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*(0|1|0?\.\d+|\d+%
 const rgbfn = /^rgba?\(\s*(\d+)\s+(\d+)\s+(\d+)(?:\s*\/\s*(0|1|0?\.\d+|\d+%))?\s*\)$/;
 const rgbperc = /^rgba?\(\s*(\d+%)\s*,\s*(\d+%)\s*,\s*(\d+%)(?:\s*,\s*(0|1|0?\.\d+|\d+%))?\s*\)$/;
 const rgbpercfn = /^rgba?\(\s*(\d+%)\s+(\d+%)\s+(\d+%)(?:\s*\/\s*(0|1|0?\.\d+|\d+%))?\s*\)$/;
-const hsl = /^hsla?\(\s*(\d+)(deg|rad|grad|turn)?\s*,\s*(\d+)%\s*,\s*(\d+)%(?:\s*,\s*(0|1|0?\.\d+|\d+%))?\s*\)$/;
+const hsl = /^hsla?\(\s*(0?\.\d+|\d+)(deg|rad|grad|turn)?\s*,\s*(\d+)%\s*,\s*(\d+)%(?:\s*,\s*(0?\.\d+|\d+%))?\s*\)$/;
+const hslws = /^hsla?\(\s*(0?\.\d+|\d+)(deg|rad|grad|turn)?\s+(\d+)%\s+(\d+)%(?:\s*\/\s*(0?\.\d+|\d+%))?\s*\)$/;
 
 function contains(haystack, needle) {
   return haystack.indexOf(needle) > -1;
@@ -151,8 +152,8 @@ function fromRgbString(str) {
   return fromRgba([r, g, b, a]);
 }
 
-function fromHslString(str) {
-  let [, h, unit, s, l, a] = hsl.exec(str);
+function fromHslString(reg, str) {
+  let [, h, unit, s, l, a] = reg.exec(str);
   unit = unit || 'deg';
   h = unitConverter(parseFloat(h), unit, 'deg');
   s = parseFloat(s);
@@ -175,7 +176,11 @@ export function fromString(str) {
   }
 
   if (hsl.test(str)) {
-    return fromHslString(str);
+    return fromHslString(hsl, str);
+  }
+
+  if (hslws.test(str)) {
+    return fromHslString(hslws, str);
   }
 
   return null;


### PR DESCRIPTION
Your `hsl` parsing only supports with commas whereas it's also possible to only separate values with whitespace characters:

```
hsl(hue saturation lightness)
hsl(hue saturation lightness / alpha)

hsl(hue, saturation, lightness)
hsl(hue, saturation, lightness, alpha)

hsla(hue saturation lightness)
hsla(hue saturation lightness / alpha)

hsla(hue, saturation, lightness)
hsla(hue, saturation, lightness, alpha)
```

From MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl#syntax